### PR TITLE
Add Flapper landing page prototype

### DIFF
--- a/flapper_web/admin.html
+++ b/flapper_web/admin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flapper Admin</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Admin Dashboard</h1>
+  <form id="add-product-form">
+    <input type="text" id="name" placeholder="Product name" required>
+    <input type="text" id="category" placeholder="Category" required>
+    <input type="url" id="video" placeholder="Promo video URL">
+    <button type="submit">Add Product</button>
+  </form>
+
+  <h2>Existing Products</h2>
+  <div id="product-admin-list"></div>
+
+  <footer>
+    <a href="index.html">Back to landing page</a>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/flapper_web/index.html
+++ b/flapper_web/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flapper - Best Products</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Flapper</h1>
+    <p>Your landing page for the products I love.</p>
+  </header>
+
+  <section id="promo-video">
+    <h2>Discover our latest picks</h2>
+    <video controls width="320" height="240" src="assets/promo.mp4">Your browser does not support the video tag.</video>
+  </section>
+
+  <section id="product-list">
+    <h2>Products</h2>
+    <div id="products"></div>
+  </section>
+
+  <footer>
+    <a href="admin.html">Admin Dashboard</a>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/flapper_web/script.js
+++ b/flapper_web/script.js
@@ -1,0 +1,48 @@
+function loadProducts() {
+  const products = JSON.parse(localStorage.getItem('products') || '[]');
+  const container = document.getElementById('products');
+  if (!container) return;
+  container.innerHTML = '';
+  products.forEach(p => {
+    const div = document.createElement('div');
+    div.className = 'product';
+    div.textContent = `${p.name} (${p.category}) - Code: ${p.code}`;
+    container.appendChild(div);
+  });
+}
+
+function loadAdminProducts() {
+  const products = JSON.parse(localStorage.getItem('products') || '[]');
+  const container = document.getElementById('product-admin-list');
+  if (!container) return;
+  container.innerHTML = '';
+  products.forEach(p => {
+    const div = document.createElement('div');
+    div.className = 'product';
+    div.textContent = `${p.name} (${p.category}) - Code: ${p.code}`;
+    container.appendChild(div);
+  });
+}
+
+function generateCode(name) {
+  return name.replace(/\s+/g, '').toUpperCase() + '-' + Math.floor(Math.random() * 10000);
+}
+
+const form = document.getElementById('add-product-form');
+if (form) {
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const name = document.getElementById('name').value.trim();
+    const category = document.getElementById('category').value.trim();
+    const video = document.getElementById('video').value.trim();
+    const products = JSON.parse(localStorage.getItem('products') || '[]');
+    const code = generateCode(name);
+    products.push({ name, category, video, code });
+    localStorage.setItem('products', JSON.stringify(products));
+    form.reset();
+    loadAdminProducts();
+  });
+  loadAdminProducts();
+} else {
+  loadProducts();
+}

--- a/flapper_web/style.css
+++ b/flapper_web/style.css
@@ -1,0 +1,33 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  background-color: #4CAF50;
+  color: white;
+  padding: 1em;
+  text-align: center;
+}
+
+section {
+  margin: 1em;
+}
+
+footer {
+  text-align: center;
+  margin-top: 2em;
+  padding: 1em;
+  background-color: #f0f0f0;
+}
+
+#products .product {
+  border: 1px solid #ccc;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+#product-admin-list .product {
+  margin-bottom: 0.5em;
+}


### PR DESCRIPTION
## Summary
- create `flapper_web` folder with simple landing page
- add admin dashboard page and placeholder video asset
- implement basic styling and a small JS script for storing products

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68703655bcc883318b4aa50a62870b30